### PR TITLE
Update typst-action to v0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build Typst
-      uses: lvignoli/typst-action@v1
+      uses: lvignoli/typst-action@v0
       with:
         source_file: euler-lagrange.typ
     - name: Upload PDF file


### PR DESCRIPTION
Hi @msakuta.

I have refactored `typst-action`, and change the versioning in the process.
v1 has been deleted, you should now use v0 as suggested in the PR, which mirrors the current unstable API of the Typst CLI.

You can also use `lvignoli/typst-action@main`, which be the same thing for a while, as I'll move the v0 tag to the tip of main regularly.